### PR TITLE
Updated django in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bokeh==0.12.7
 numpy==1.13.0
 dj-database-url==0.4.1
-Django==1.11.1
+django>=1.11.23
 gunicorn==19.6.0
 psycopg2==2.6.2
 whitenoise==3.2


### PR DESCRIPTION
This PR updates the `Django` requirement in `requirements.txt` to `django>=1.11.23` to satisfy [this security alert](https://github.com/OpenSourceEcon/OGvisualizations/network/alert/requirements.txt/django/open).